### PR TITLE
Target .NET 6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,15 +20,10 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v1
 
-    - name: Install .NET 3.1
+    - name: Install .NET 6.0
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '3.1.x'
-
-    - name: Install .NET 5.0
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: '5.0.x'
+        dotnet-version: '6.0.x'
 
     - name: Build (Release)
       run: |

--- a/src/Broslyn.Tests/Broslyn.Tests.csproj
+++ b/src/Broslyn.Tests/Broslyn.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/Broslyn/Broslyn.csproj
+++ b/src/Broslyn/Broslyn.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
 	<Description>A lightweight utility library to create a Roslyn AdhocWorkspace from an existing solution`/`csproj.</Description>
 	<Copyright>Alexandre Mutel</Copyright>
 	<NeutralLanguage>en-US</NeutralLanguage>
@@ -23,8 +23,8 @@
 
   <ItemGroup>
     <None Include="../../img/logo.png" Pack="true" PackagePath="" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.7.0" />
-    <PackageReference Include="MSBuild.StructuredLogger" Version="2.1.215" />
+	<PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.0.1" />
+    <PackageReference Include="MSBuild.StructuredLogger" Version="2.1.545" />
     <!--Add support for sourcelink-->
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.*" PrivateAssets="All" />
   </ItemGroup>

--- a/src/global.json
+++ b/src/global.json
@@ -1,6 +1,6 @@
 {
     "sdk": {
-        "version": "5.0",
+        "version": "6.0",
         "rollForward": "latestMinor"
     }
 }


### PR DESCRIPTION
This change updates `Microsoft.CodeAnalysis.CSharp.Workspaces` & `MSBuild.StructuredLogger`, and adds a target for .NET 6 (so that we don't take the .NET Framework transitive dependency on `Microsoft.Build` which is the best match for `netstandard2.0`).